### PR TITLE
Add DuckDB FDW references to Cargo.toml

### DIFF
--- a/wrappers/Cargo.toml
+++ b/wrappers/Cargo.toml
@@ -128,6 +128,7 @@ notion_fdw = [
     "url",
     "thiserror",
 ]
+duckdb_fdw = [] # Added duckdb_fdw feature
 # Does not include helloworld_fdw because of its general uselessness
 all_fdws = [
     "airtable_fdw",
@@ -142,6 +143,7 @@ all_fdws = [
     "redis_fdw",
     "cognito_fdw",
     "notion_fdw",
+    "duckdb_fdw", # Included duckdb_fdw in all_fdws feature list
 ]
 
 [dependencies]


### PR DESCRIPTION
Adds support for `duckdb_fdw` in the `Cargo.toml` file of the `wrappers` package.

- Introduces a new feature `duckdb_fdw` under the `[features]` section, aligning with the existing structure for other FDWs.
- Includes `duckdb_fdw` in the `all_fdws` feature list, ensuring it is part of the collective build process alongside other FDWs.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/burggraf/wrappers?shareId=f497e5ed-8c66-4fdb-9468-2d03c2ba4651).