### PR TITLE
Add setup script for testing environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,19 @@ wrappers=# select * from hello;
 (1 row)
 ```
 
+## Testing Setup
+
+To set up a testing environment for the wrappers, you can use the `setup_test_env.sh` script located in the root directory of the project. This script installs all the prerequisites for testing the wrappers, including the Rust toolchain, pgrx dependencies, and runs the helloworld wrapper as a test.
+
+To use the script, simply run:
+(MacOS only)
+
+```bash
+./setup_test_env.sh
+```
+
+This will ensure that all necessary components are installed and configured correctly for testing.
+
 ## Running tests
 
 In order to run tests in `wrappers`:

--- a/setup_test_env.sh
+++ b/setup_test_env.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Install Rust Toolchain
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Install pgrx dependencies
+brew install git icu4c pkg-config
+
+# Install pgrx
+cargo install cargo-pgrx --version 0.11.3 --locked
+cargo pgrx init
+
+# Run the helloworld wrapper as a test
+cd wrappers/wrappers
+cargo pgrx run pg15 --features helloworld_fdw

--- a/wrappers/README.md
+++ b/wrappers/README.md
@@ -15,3 +15,5 @@ This is a collection of FDWs built by [Supabase](https://www.supabase.com). We c
 - [SQL Server](./src/fdw/mssql_fdw): A FDW for [Microsoft SQL Server](https://www.microsoft.com/en-au/sql-server/) which supports data read only.
 - [Redis](./src/fdw/redis_fdw): A FDW for [Redis](https://redis.io/) which supports data read only.
 - [Notion](./src/fdw/notion_fdw): A FDW for [Notion](https://notion.so/) which supports users read only.
+
+To set up a testing environment for the wrappers, you can use the `setup_test_env.sh` script (on MacOS) located in the root directory of the project. This script installs all the prerequisites for testing the wrappers, including the Rust toolchain, pgrx dependencies, and runs the helloworld wrapper as a test.


### PR DESCRIPTION
Related to #1

Adds a new script and updates documentation to facilitate testing setup for the project.

- Introduces `setup_test_env.sh`, a new script in the root directory, which automates the installation of the Rust toolchain, pgrx dependencies, and runs the helloworld wrapper as a test. This script streamlines the process of setting up a local testing environment for contributors and developers.
- Updates the `README.md` file to include a new "Testing Setup" section. This section provides instructions on how to use the newly added `setup_test_env.sh` script to prepare a testing environment, ensuring users have all necessary components installed and configured correctly.
- Modifies the `wrappers/README.md` file to mention the `setup_test_env.sh` script. This addition aims to inform users about the script's availability and its role in simplifying the testing setup process for the wrappers.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/burggraf/wrappers/issues/1?shareId=0f35a198-729f-4934-bee7-da0b558281d3).